### PR TITLE
Layout fixes

### DIFF
--- a/docs/CONTENT.md
+++ b/docs/CONTENT.md
@@ -187,7 +187,7 @@ This website uses the default Carbon grid, in order to to this you will need to 
 
 All content and componnents will need to be wrapped innside a `<grid>` component **except** the `<title-block>`, which utilizes its own grid code.
 
-The grid component has one prop, background which is used to tell the section what background color to use. The following colors are available.
+The grid component has a prop, background, which is used to tell the section what background color to use. The following colors are available.
 
 - `black`
 - `white`
@@ -196,8 +196,13 @@ The grid component has one prop, background which is used to tell the section wh
 - `gray-100`
 - `gray-white` _50/50 gray-100 and white, gray-100 on top_
 
+The other prop available is `classname` which alows you to add a class you can target via css to the wrapping div. We are using the following classnames.
+
+`background--header`
+`background--tile`
+
 ```
-<grid background="gray-10">
+<grid background="gray-10" classname="background--header">
 
 Markdown, html, custom components
 

--- a/src/components/AnchorLinks/anchor-links.scss
+++ b/src/components/AnchorLinks/anchor-links.scss
@@ -60,7 +60,7 @@
     position: absolute;
     left: auto;
     right: -1.27rem;
-    bottom: 2rem;
+    bottom: rem(40px);
     width: 25%;
     padding: 0;
   }

--- a/src/components/Grid/Grid.js
+++ b/src/components/Grid/Grid.js
@@ -5,20 +5,23 @@ import classnames from 'classnames';
 export class Grid extends React.Component {
   static propTypes = {
     children: PropTypes.node,
+
+    /**
+     * set grid background color
+     */
     background: PropTypes.string,
 
     /**
-     * Default to true, set to false to remove grid spacinng
+     * Specify a class name for grid wrapper
      */
-    margin: PropTypes.string,
+    className: PropTypes.string,
   };
 
   render() {
-    const { children, background, margin } = this.props;
+    const { children, className, background, margin } = this.props;
 
     const classNames = classnames({
       background: true,
-      'background--nomargin': margin === 'false',
       'background--black': background === 'black',
       'background--white': background === 'white',
       'background--gray-10': background === 'gray-10',
@@ -33,7 +36,12 @@ export class Grid extends React.Component {
     });
 
     return (
-      <div className={classNames}>
+      <div
+        className={
+          className !== undefined
+            ? `${className} ${classNames}`
+            : `${classNames}`
+        }>
         <div className="ibm--grid">
           <div className="ibm--row">{children}</div>
         </div>

--- a/src/components/Grid/Grid.js
+++ b/src/components/Grid/Grid.js
@@ -70,6 +70,10 @@ export class Column extends React.Component {
      */
     offset_lg: PropTypes.string,
     /**
+     * Specify the col offset at medium breakpoint
+     */
+    offset_md: PropTypes.string,
+    /**
      * Specify a left border
      */
     border: PropTypes.string,
@@ -80,7 +84,16 @@ export class Column extends React.Component {
   };
 
   render() {
-    const { children, sm, md, lg, offset_lg, border, text_align } = this.props;
+    const {
+      children,
+      sm,
+      md,
+      lg,
+      offset_lg,
+      offset_md,
+      border,
+      text_align,
+    } = this.props;
     let classNames = '';
     if (border) classNames += `ibm--col-border `;
     if (text_align === 'right') classNames += `ibm--col-right `;
@@ -88,6 +101,7 @@ export class Column extends React.Component {
     if (md) classNames += `ibm--col-md-${md} `;
     if (sm) classNames += `ibm--col-sm-${sm} `;
     if (offset_lg) classNames += `ibm--offset-lg-${offset_lg} `;
+    if (offset_md) classNames += `ibm--offset-md-${offset_md} `;
 
     return <div className={classNames}>{children}</div>;
   }

--- a/src/components/Grid/grid.scss
+++ b/src/components/Grid/grid.scss
@@ -9,8 +9,12 @@
     padding-bottom: rem(80px);
     padding-top: rem(56px);
   }
+}
 
-  &:last-child {
+.background:last-child {
+  padding-bottom: rem(48px);
+
+  @include breakpoint('lg') {
     padding-bottom: rem(128px);
   }
 }
@@ -72,7 +76,13 @@
 // Columns
 //----------------------------
 .ibm--col-right {
-  text-align: right;
+  @include breakpoint('md') {
+    text-align: right;
+
+    .page-p {
+      padding-right: 0;
+    }
+  }
 }
 
 .container .ibm--col-border {

--- a/src/components/Grid/grid.scss
+++ b/src/components/Grid/grid.scss
@@ -2,7 +2,7 @@
 // Background
 //----------------------------
 .background {
-  padding-bottom: rem(32px);
+  padding-bottom: rem(64px);
   padding-top: rem(32px);
 
   @include breakpoint('lg') {

--- a/src/components/Grid/grid.scss
+++ b/src/components/Grid/grid.scss
@@ -15,18 +15,12 @@
   }
 }
 
-.background--nomargin {
-  padding-top: rem(32px);
-  padding-bottom: 0;
-
-  &:last-child {
-    padding-bottom: 0;
-    margin-bottom: rem(128px);
-  }
-}
-
-.page-content > div div.background:first-child {
+.background--header {
   padding-top: 2rem;
+
+  @include breakpoint('lg') {
+    height: 560px;
+  }
 }
 
 .background--white {

--- a/src/components/Markdown/markdown.scss
+++ b/src/components/Markdown/markdown.scss
@@ -68,8 +68,12 @@
 .page-h3 {
   @include type-style('heading-03');
   color: $text-01;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1rem;
   padding-right: 9%;
+
+  @include breakpoint('md') {
+    margin-bottom: 1.5rem;
+  }
 }
 
 .background--inverse .page-h3 {
@@ -194,7 +198,11 @@ blockquote em {
 hr {
   border: none;
   border-top: 1px solid $ibm-colors__gray--50;
-  margin-top: -2rem;
+  margin-top: -1rem;
+
+  @include breakpoint('md') {
+    margin-top: -2rem;
+  }
 }
 
 .background--black blockquote hr,

--- a/src/components/Tile/tile.scss
+++ b/src/components/Tile/tile.scss
@@ -13,6 +13,9 @@
 }
 
 .background--tile .tile {
+  margin-bottom: 0;
+  margin-left: 0;
+
   @include breakpoint('lg') {
     height: 496px;
   }
@@ -23,14 +26,11 @@
 //----------------------------
 
 .tile {
-  margin-left: -1rem;
-  margin-right: -1rem;
+  margin-bottom: 1rem;
   position: relative;
 
   @include breakpoint('md') {
-    display: block;
-    margin-left: 0;
-    margin-right: 0;
+    margin-left: -1rem;
   }
 }
 
@@ -77,11 +77,7 @@ a.bx--tile {
 }
 
 .tile__img {
-  min-width: 50%;
-
-  @include breakpoint('md') {
-    width: 100%;
-  }
+  width: 100%;
 }
 
 .tile__img img {
@@ -113,55 +109,40 @@ a.bx--tile--clickable--dark .tile__link-icon svg {
   color: $ibm-colors__gray--90;
 }
 
-.bx--aspect-ratio--2x1 {
-  padding-bottom: 100%;
-
-  @include breakpoint('md') {
-    padding-bottom: 50%;
-  }
-}
-
 //----------------------------
 // Tile inside 4
 //----------------------------
-.ibm--col-lg-4 .tile {
-  margin-bottom: rem(32px);
-  display: flex;
-
-  @include breakpoint('md') {
-    display: block;
-    margin-left: -1rem;
-  }
-}
-
-.ibm--col-lg-4 a.bx--tile {
-  width: 50%;
-
-  @include breakpoint('md') {
-    width: 100%;
-  }
-}
+/* .ibm--col-lg-4 .tile {
+  margin-bottom: 1rem;
+} */
 
 //----------------------------
 // Tile inside 12 or 16
 //----------------------------
+
 .ibm--col-lg-8,
 .ibm--col-lg-12,
 .ibm--col-lg-16 {
   .tile {
     @include breakpoint('md') {
-      margin: 0 0 0 -1rem;
+      margin-right: -1rem;
+    }
+
+    @include breakpoint('lg') {
+      margin-right: 0;
     }
   }
 
   a.bx--tile {
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    width: 50%;
+    @include breakpoint('md') {
+      position: absolute;
+      bottom: 0;
+      right: 1rem;
+      width: calc(50% - 1rem);
+    }
 
     @include breakpoint('lg') {
-      width: calc(50% - 2rem);
+      right: 0;
     }
   }
 }

--- a/src/components/Tile/tile.scss
+++ b/src/components/Tile/tile.scss
@@ -1,6 +1,27 @@
 //----------------------------
+// Tile background
+//----------------------------
+.background--tile {
+  padding-top: rem(64px);
+  padding-bottom: 0;
+  margin-bottom: 1rem;
+
+  &:last-child {
+    padding-bottom: 0;
+    margin-bottom: rem(128px);
+  }
+}
+
+.background--tile .tile {
+  @include breakpoint('lg') {
+    height: 496px;
+  }
+}
+
+//----------------------------
 // Tile
 //----------------------------
+
 .tile {
   margin-left: -1rem;
   margin-right: -1rem;

--- a/src/components/Tile/tile.scss
+++ b/src/components/Tile/tile.scss
@@ -82,6 +82,7 @@ a.bx--tile {
   position: relative;
   padding-bottom: 100%;
   overflow: hidden;
+  z-index: 1;
 
   @include breakpoint('md') {
     height: auto;

--- a/src/components/Tile/tile.scss
+++ b/src/components/Tile/tile.scss
@@ -78,10 +78,41 @@ a.bx--tile {
 
 .tile__img {
   width: 100%;
+  height: 0;
+  position: relative;
+  padding-bottom: 100%;
+  overflow: hidden;
+
+  @include breakpoint('md') {
+    height: auto;
+    padding-bottom: 0;
+  }
 }
 
-.tile__img img {
+.tile__img .gatsby-resp-image-wrapper {
+  position: absolute !important;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   width: 100%;
+  height: 100%;
+  z-index: 100;
+
+  @include breakpoint('md') {
+    position: relative !important;
+  }
+}
+
+.tile__img .gatsby-resp-image-image {
+  max-width: unset;
+  height: 100%;
+  width: auto !important;
+
+  @include breakpoint('md') {
+    max-width: 100%;
+    width: 100% !important;
+  }
 }
 
 // Dark

--- a/src/components/TitleBlock/title-block.scss
+++ b/src/components/TitleBlock/title-block.scss
@@ -40,6 +40,7 @@
   @include type-style('display-03');
   font-weight: 300;
   font-size: calc(36px + 56 * ((100vw - 320px) / 1264));
+  padding-bottom: 1.5rem;
 
   @include breakpoint('lg') {
     padding-bottom: 2rem;

--- a/src/components/TitleBlock/title-block.scss
+++ b/src/components/TitleBlock/title-block.scss
@@ -24,9 +24,10 @@
 }
 
 .title-block .eye-bee-m {
-  height: 67px;
-  width: 28px;
+  height: 72px;
+  width: 30px;
   margin-bottom: 2rem;
+  margin-left: rem(8px);
 }
 
 .title-block__content {

--- a/src/content/approach/approach.md
+++ b/src/content/approach/approach.md
@@ -32,7 +32,7 @@ responsibility to the people we serve.</p>
 </column>
 
 </grid>
-<grid background="black" margin="false">
+<grid background="black" classname="background--tile">
 <column lg="4" offset_lg="1">
 
 <h2><strong>Design Philosophy</strong><br>The beliefs behind everything we do.</h2>
@@ -44,14 +44,13 @@ Design is about giving people a path, both emotionally and functionally, towards
 
 <tile
     href="/approach/design-philosophy"
-    caption="caption"
-    title="title">
+    title="Learn more">
 <img src="images/Image_1.svg" alt="Geometric shapes"/>
 </tile>
 
 </column>
 </grid>
-<grid background="gray-20" margin="false">
+<grid background="gray-20" classname="background--tile">
 <column lg="4" offset_lg="1">
 
 <h2><strong>Design Thinking</strong><br>Human-centered design at scale.</h2>
@@ -63,14 +62,13 @@ Learn how you can apply the same framework our teams use every day.
 
 <tile
     href="/approach/design-thinking"
-    caption="caption"
-    title="title">
+    title="Learn more">
 <img src="images/Image_2.svg" alt="Geometric shapes"/>
 </tile>
 
 </column>
 </grid>
-<grid background="gray-80" margin="false">
+<grid background="gray-80" classname="background--tile">
 <column lg="4" offset_lg="1">
 
 <h2><strong>Design Services</strong><br>Your business partner by design.</h2>
@@ -82,8 +80,7 @@ Partner with us to help define your strategy, create exceptional experiences, an
 
 <tile
     href="/approach/design-services"
-    caption="caption"
-    title="title">
+    title="Learn more">
 <img src="images/Image_3.svg" alt="Ven diagram emphasizing overlapping area"/>
 </tile>
 

--- a/src/content/approach/design-philosophy/design-philosophy.md
+++ b/src/content/approach/design-philosophy/design-philosophy.md
@@ -14,7 +14,7 @@ Given our scale and scope, good design is not just a requirement, it’s a deepe
 </column>
 <column lg="9" offset_lg="3">
 
-<iframe src="https://player.vimeo.com/video/293453905?title=0&byline=0&portrait=0?color=ff0000" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen />
+<iframe title="video" src="https://player.vimeo.com/video/293453905?title=0&byline=0&portrait=0?color=ff0000" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen />
 
 </column>
 </grid>

--- a/src/content/approach/design-philosophy/design-philosophy.md
+++ b/src/content/approach/design-philosophy/design-philosophy.md
@@ -2,8 +2,8 @@
 title: Design Philosophy
 ---
 
-<grid background="gray-100">
-<column lg="5">
+<grid background="gray-100" classname="background--header">
+<column lg="4">
 
 ## **Design Philosophy**
 
@@ -12,7 +12,7 @@ IBMers believe in progress — that by applying intelligence, reason and science
 Given our scale and scope, good design is not just a requirement, it’s a deeper responsibility to the relationships we seek to serve.
 
 </column>
-<column lg="9" offset_lg="2">
+<column lg="9" offset_lg="3">
 
 <iframe src="https://player.vimeo.com/video/293453905?title=0&byline=0&portrait=0?color=ff0000" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen />
 

--- a/src/content/approach/design-services/design-services.md
+++ b/src/content/approach/design-services/design-services.md
@@ -2,8 +2,8 @@
 title: Design Services
 ---
 
-<grid background="gray-80">
-<column lg="5">
+<grid background="gray-80" classname="background--header">
+<column lg="4">
 
 ## **Design services**
 
@@ -12,7 +12,7 @@ Most companies make things for their clients. We prefer to co-create with you.
 At IX, we blend design with innovative technologies and business strategy to offer you a comprehensive global business design partner.
 
 </column>
-<column lg="9" offset_lg="2">
+<column lg="9" offset_lg="3">
 
 <iframe src="https://player.vimeo.com/video/293453905?title=0&byline=0&portrait=0?color=ff0000" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen />
 

--- a/src/content/approach/design-services/design-services.md
+++ b/src/content/approach/design-services/design-services.md
@@ -14,7 +14,7 @@ At IX, we blend design with innovative technologies and business strategy to off
 </column>
 <column lg="9" offset_lg="3">
 
-<iframe src="https://player.vimeo.com/video/293453905?title=0&byline=0&portrait=0?color=ff0000" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen />
+<iframe title="video" src="https://player.vimeo.com/video/293453905?title=0&byline=0&portrait=0?color=ff0000" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen />
 
 </column>
 </grid>

--- a/src/content/approach/design-thinking/design-thinking.md
+++ b/src/content/approach/design-thinking/design-thinking.md
@@ -14,7 +14,7 @@ We built on that idea, adding strategies, tactics and activities to create a fra
 </column>
 <column lg="9" offset_lg="3">
 
-<iframe src="https://player.vimeo.com/video/293453905?title=0&byline=0&portrait=0?color=ff0000" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen />
+<iframe title="video" src="https://player.vimeo.com/video/293453905?title=0&byline=0&portrait=0?color=ff0000" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen />
 
 </column>
 </grid>

--- a/src/content/approach/design-thinking/design-thinking.md
+++ b/src/content/approach/design-thinking/design-thinking.md
@@ -2,8 +2,8 @@
 title: Design Thinking
 ---
 
-<grid background="gray-20">
-<column lg="5">
+<grid background="gray-20" classname="background--header">
+<column lg="4">
 
 ## **Design Thinking Framework**
 
@@ -12,7 +12,7 @@ At its core, design thinking is the idea of putting human problems first.
 We built on that idea, adding strategies, tactics and activities to create a framework uniquely tailored to address the challenges and scale of the modern enterprise.
 
 </column>
-<column lg="9" offset_lg="2">
+<column lg="9" offset_lg="3">
 
 <iframe src="https://player.vimeo.com/video/293453905?title=0&byline=0&portrait=0?color=ff0000" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen />
 

--- a/src/content/impact/impact.md
+++ b/src/content/impact/impact.md
@@ -66,7 +66,7 @@ the means.<br>
   </tile>
 
 </column>
-<column lg="4" md="4" offset_md="4">
+<column lg="4" md="4" offset_lg="0"  offset_md="4">
 
   <tile title="This mobile app teaches quantum computing through a puzzle game" caption="thenextweb" href="/impact/template/">
     <img src="images/Image_4.png" alt="quantum puzzle game"/>
@@ -99,7 +99,7 @@ the means.<br>
   </tile>
 
 </column>
-<column lg="4" md="4" offset_md="4">
+<column lg="4" md="4" offset_lg="0"  offset_md="4">
 
   <tile title="X-Force Command takes their immersive cybersecurity training on the road" caption="nytimes" href="/impact/template/">
     <img src="images/Image_7.png" alt="xforce dashboard"/>
@@ -133,7 +133,7 @@ the means.<br>
   </tile>
 
 </column>
-<column lg="4" md="4" offset_md="4">
+<column lg="4" md="4" offset_lg="0"  offset_md="4">
 
   <tile title="The business case for our open source font" caption="source" href="/impact/template/">
     <img src="images/Image_10.png" alt="Mike looking at Plex on a table"/>

--- a/src/content/impact/impact.md
+++ b/src/content/impact/impact.md
@@ -14,12 +14,17 @@ the means.<br>
 
 <p size="xl">In a world where every challenge is complex and unique, good design values unity over uniformity. Explore some of the different types of outcomes we’ve delivered for our clients and users below.</p>
 
-<icon title="ArrowDown32"></icon>
+<icon name="ArrowDown32"></icon>
 
 </column>
 </grid>
 
 <grid background="gray-10">
+<column lg="16">
+
+<hr>
+
+</column>
 <column lg="4">
 
 ### Think
@@ -37,6 +42,11 @@ the means.<br>
 
 </grid>
 <grid background="gray-10">
+<column lg="16">
+
+<hr>
+
+</column>
 <column lg="4" md="4">
 
 ### Quantum
@@ -65,6 +75,11 @@ the means.<br>
 </column>
 </grid>
 <grid background="gray-10">
+<column lg="16">
+
+<hr>
+
+</column>
 <column lg="4">
 
 ### Security
@@ -94,6 +109,11 @@ the means.<br>
 </grid>
 
 <grid background="gray-10">
+<column lg="16">
+
+<hr>
+
+</column>
 <column lg="4">
 
 ### Plex

--- a/src/content/impact/impact.md
+++ b/src/content/impact/impact.md
@@ -47,7 +47,7 @@ the means.<br>
 <hr>
 
 </column>
-<column lg="4" md="4">
+<column lg="4" md="8">
 
 ### Quantum
 
@@ -66,7 +66,7 @@ the means.<br>
   </tile>
 
 </column>
-<column lg="4" md="4">
+<column lg="4" md="4" offset_md="4">
 
   <tile title="This mobile app teaches quantum computing through a puzzle game" caption="thenextweb" href="/impact/template/">
     <img src="images/Image_4.png" alt="quantum puzzle game"/>
@@ -80,7 +80,7 @@ the means.<br>
 <hr>
 
 </column>
-<column lg="4">
+<column lg="4" md="8">
 
 ### Security
 
@@ -99,7 +99,7 @@ the means.<br>
   </tile>
 
 </column>
-<column lg="4" md="4">
+<column lg="4" md="4" offset_md="4">
 
   <tile title="X-Force Command takes their immersive cybersecurity training on the road" caption="nytimes" href="/impact/template/">
     <img src="images/Image_7.png" alt="xforce dashboard"/>
@@ -114,7 +114,7 @@ the means.<br>
 <hr>
 
 </column>
-<column lg="4">
+<column lg="4" md="8">
 
 ### Plex
 
@@ -133,7 +133,7 @@ the means.<br>
   </tile>
 
 </column>
-<column lg="4" md="4">
+<column lg="4" md="4" offset_md="4">
 
   <tile title="The business case for our open source font" caption="source" href="/impact/template/">
     <img src="images/Image_10.png" alt="Mike looking at Plex on a table"/>

--- a/src/content/index.md
+++ b/src/content/index.md
@@ -58,7 +58,7 @@ with time-tested business acumen, the results speak for themselves.</p>
 </tile>
 
 </column>
-<column lg="4" md="4" offset_md="4">
+<column lg="4" md="4" offset_lg="0"  offset_md="4">
 
 <tile
     caption="tdc/news"

--- a/src/content/index.md
+++ b/src/content/index.md
@@ -58,7 +58,7 @@ with time-tested business acumen, the results speak for themselves.</p>
 </tile>
 
 </column>
-<column lg="4" md="4">
+<column lg="4" md="4" offset_md="4">
 
 <tile
     caption="tdc/news"

--- a/src/content/index.md
+++ b/src/content/index.md
@@ -12,7 +12,7 @@ people we serve.</span>
 <grid background="gray-white">
 <column lg="16">
 
-<iframe src="https://player.vimeo.com/video/293453905?title=0&byline=0&portrait=0?color=ff0000" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen />
+<iframe src="https://player.vimeo.com/video/293453905?muted=1&autoplay=1&loop=1?title=0&byline=0&portrait=0?color=ff0000" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen />
 
 </column>
 </grid>

--- a/src/content/index.md
+++ b/src/content/index.md
@@ -12,7 +12,7 @@ people we serve.</span>
 <grid background="gray-white">
 <column lg="16">
 
-<iframe src="https://player.vimeo.com/video/293453905?muted=1&autoplay=1&loop=1?title=0&byline=0&portrait=0?color=ff0000" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen />
+<iframe title="video" src="https://player.vimeo.com/video/293453905?muted=1&autoplay=1&loop=1?title=0&byline=0&portrait=0?color=ff0000" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen />
 
 </column>
 </grid>

--- a/src/content/practices/practices.md
+++ b/src/content/practices/practices.md
@@ -74,7 +74,7 @@ meets pragmatic.</span>
 </tile>
 
 </column>
-<column lg="4" md="4">
+<column lg="4" md="4" offset_md="4">
 
 <tile
     dark="true"

--- a/src/content/practices/practices.md
+++ b/src/content/practices/practices.md
@@ -74,7 +74,7 @@ meets pragmatic.</span>
 </tile>
 
 </column>
-<column lg="4" md="4" offset_md="4">
+<column lg="4" md="4" offset_lg="0"  offset_md="4">
 
 <tile
     dark="true"

--- a/src/content/practices/practices.md
+++ b/src/content/practices/practices.md
@@ -24,7 +24,7 @@ meets pragmatic.</span>
 
 <p size="xl">Tap into a growing collection of design tools, assets and resources to keep your business moving forward.</p>
 
-<icon title="ArrowDown32" color="white"></icon>
+<icon name="ArrowDown32" color="white"></icon>
 
 </column>
 </grid>

--- a/src/styles/_page.scss
+++ b/src/styles/_page.scss
@@ -57,9 +57,5 @@ img {
 .page-content > div div.background:first-child .gatsby-resp-iframe-wrapper {
   // removes the default padding around a video if its in the first grid container on a page
   @include breakpoint('lg') {
-    margin-left: -2rem;
-    margin-right: -2rem;
-    margin-top: -2rem;
-    margin-bottom: -5rem;
   }
 }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -27,6 +27,13 @@ $feature-flags: (
 @import 'carbon-components/scss/globals/scss/styles.scss';
 @import '@carbon/addons-website/scss/styles';
 
+// temp grid fix
+.container .ibm--offset-lg-0 {
+  @include breakpoint('lg') {
+    margin-left: 0;
+  }
+}
+
 //---------------------------------------
 // Page styles
 //---------------------------------------


### PR DESCRIPTION
- adds hr to Impact page Closes #94
- update rebus logo size Closes #72 
- Spacing below Large headlines in mobile/tablet Closes #101
- updates banner height on approach page & subpages Closes #71  (fyi @sstrubberg had to add a new classname prop to grid, this way we can easily target anything we need on the site with css)
- mobile/tablet tiles closes #104 closes #102 closes #107 

Hey @RyanCaruthers @sstrubberg I knocked a big chunk of the layout issues in this PR, let me know if anythinng looks off. The big thing not included is the tiles on the Approach page.