### PR TITLE
link corrections: Approach - Design Services page

### DIFF
--- a/src/content/approach/design-services/design-services.md
+++ b/src/content/approach/design-services/design-services.md
@@ -128,7 +128,7 @@ In today’s world, people expect consistent, cohesive experiences at every touc
 <column lg="16">
 
 <tile
-    href="#"
+    href="https://www.ibm.com/services/ibmix/"
     title="IBM iX"
     feature="true"
     feature_heading="Partner with us to build
@@ -149,7 +149,7 @@ In today’s world, people expect consistent, cohesive experiences at every touc
 
 <p size="sm"><br><strong>Design Philosophy</strong><br>
 Our beliefs drive everything we do. Design is about moving people forward, both emotionally and functionally.<br><br>
-<a href="/approach/design-thinking">Learn more</a> <icon color="blue" inline="true"></icon></p>
+<a href="/approach/design-philosophy">Learn more</a> <icon color="blue" inline="true"></icon></p>
 
 </column>
 <column lg="4" md="4">
@@ -157,7 +157,7 @@ Our beliefs drive everything we do. Design is about moving people forward, both 
 ![add alt](images/Image_4.png)
 
 <p size="sm"><br><strong>Design Thinking</strong><br>
-Get familiar with how to apply the framework that drives how we think and work every day. <br><br><a href="/approach/design-services">Learn more</a> <icon color="blue" inline="true"></icon></p>
+Get familiar with how to apply the framework that drives how we think and work every day. <br><br><a href="/approach/design-thinking">Learn more</a> <icon color="blue" inline="true"></icon></p>
 
 </column>
 </grid>


### PR DESCRIPTION
updated the CTA tile link to point at the iX site

updated the Design Services and Thinking links at the bottom of the page (the "keep exploring our approach section) to point at the appropriate pages on /design