### PR TITLE
link updates: Teams page

### DIFF
--- a/src/content/teams/teams.md
+++ b/src/content/teams/teams.md
@@ -192,7 +192,7 @@ Work with multi-disciplinary teams of designers, developers, offering managers a
 
 Types of roles: visual design, UX design, user research, front-end development, content design and strategy, offering management
 
-<p><a href=#><span>Open roles</span> <icon color="blue" name="ArrowUpRight20" inline="true"></icon></a></p>
+<p><a href=https://careers.ibm.com/ListJobs/All/Search/Position-Type/Early-Professional/primary-job-category/Design---Offering-Management//?lang=en><span>Open roles</span> <icon color="blue" name="ArrowUpRight20" inline="true"></icon></a></p>
 
 </column>
 <column lg="8" offset_lg="4">
@@ -262,7 +262,7 @@ Work directly with clients while partnering with IBM consultants and business st
 
 Types of role: graphic design, content design, business strategy, user and market research, consulting
 
-<p><a href=#><span>Open roles</span> <icon color="blue" name="ArrowUpRight20" inline="true"></icon></a></p>
+<p><a href=https://www.ibm.com/services/careers><span>Open roles</span> <icon color="blue" name="ArrowUpRight20" inline="true"></icon></a></p>
 
 </column>
 <column lg="8" offset_lg="4">


### PR DESCRIPTION
updated the "View open roles links" for Product and Services in the Join Us section (still waiting to hear from Brand on where they want this to point)