### PR TITLE
link updates: Practices page

### DIFF
--- a/src/content/practices/practices.md
+++ b/src/content/practices/practices.md
@@ -48,6 +48,7 @@ meets pragmatic.</span>
 <column lg="12" offset_lg="4">
 
 <tile
+    href="https://www.ibm.com/design/language/"
     size="lg"
     background="#373737"
     dark="true"
@@ -59,6 +60,7 @@ meets pragmatic.</span>
 <column lg="4" md="4" offset_lg="4">
 
 <tile
+    href="#"
     dark="true"
     title="Product Design System">
 <img src="images/Image_2.png" alt=""/>
@@ -68,6 +70,7 @@ meets pragmatic.</span>
 <column lg="4" md="4">
 
 <tile
+    href="#"
     dark="true"
     title="Digital Design System">
 <img src="images/Image_3.png" alt=""/>
@@ -77,6 +80,7 @@ meets pragmatic.</span>
 <column lg="4" md="4" offset_lg="0"  offset_md="4">
 
 <tile
+    href="https://www.ibm.com/plex/"
     dark="true"
     title="IBM Plex typeface">
 <img src="images/Image_4.png" alt=""/>
@@ -103,6 +107,7 @@ meets pragmatic.</span>
 <column lg="12" offset_lg="4">
 
 <tile
+    href="https://www.ibm.com/design/thinking/"
     size="lg"
     background="#C5DEFF"
     dark="true"
@@ -131,6 +136,7 @@ meets pragmatic.</span>
 <column lg="12" offset_lg="4">
 
 <tile
+    href="https://www.ibm.com/design/research/"
     size="lg"
     background="#F2BDD8"
     dark="true"

--- a/src/content/practices/practices.md
+++ b/src/content/practices/practices.md
@@ -60,7 +60,7 @@ meets pragmatic.</span>
 <column lg="4" md="4" offset_lg="4">
 
 <tile
-    href="#"
+    href="https://www.ibm.com/design/product/"
     dark="true"
     title="Product Design System">
 <img src="images/Image_2.png" alt=""/>


### PR DESCRIPTION
adding the appropriate links to the tiles on this page

NOTE: the Product and Digital System tiles are still linkless... the new IDL site (currently behind the firewall) is supposed to be public before Think, but 1) not sure exactly when that's supposed to happen, and 2) not sure if all of the urls will stay the same, just without the "w3" at the front