### PR TITLE
fix(philosophy-illustration): change bg size to not cut off illustration

### DIFF
--- a/src/components/Grid/grid.scss
+++ b/src/components/Grid/grid.scss
@@ -80,7 +80,7 @@
       margin-left: 0;
       height: 100%;
       top: -1rem;
-      background-size: 100%;
+      background-size: 99.9%;
       background-position: right;
       padding-bottom: 0;
     }


### PR DESCRIPTION
Closes #287 

**Changed**

- changed the bg size for all approach sub page banners since I noticed one of the other svg's was just slightly starting to cut off as well at certain breakpoints. 

<img width="240" alt="screen shot 2019-02-04 at 2 03 48 pm" src="https://user-images.githubusercontent.com/32556167/52234026-4af7e700-2886-11e9-9318-46a1180c4cea.png">

