### PR TITLE
fix(mobile-nav): approach toggle double-click bug to single click

### DIFF
--- a/src/components/SiteHeader/SiteHeader.js
+++ b/src/components/SiteHeader/SiteHeader.js
@@ -104,7 +104,7 @@ const SiteHeader = ({
               <SideNavItems>
                 <SideNavMenu
                   title="Approach"
-                  defaultExpanded={approachActive ? 'true' : 'false'}>
+                  defaultExpanded={approachActive ? true : false}>
                   <SideNavMenuItem to="/approach/" element={Link}>
                     Overview
                   </SideNavMenuItem>


### PR DESCRIPTION
Closes #330 

**Changed**

- `defaultExpanded` on `SideNavMenu` to bool instead of string. This seemed to fix it for me. The rest of the nav should still be working as expected but it looked like the SideNavMenu toggle function from the UI shell was expecting a bool not string, may be why we were having to double click.
