### PR TITLE
Fix:App switcher is linking to next.carbon

### DIFF
--- a/src/components/SiteHeader/SiteHeader.js
+++ b/src/components/SiteHeader/SiteHeader.js
@@ -149,7 +149,7 @@ const SiteHeader = ({
                   linkText: 'IBM Design Language',
                 },
                 {
-                  href: 'https://next.carbondesignsystem.com',
+                  href: 'https://www.carbondesignsystem.com',
                   linkText: 'IBM Product Design',
                 },
                 {


### PR DESCRIPTION
changed the URL to www.carbondesignsystem.com

<img width="844" alt="Screen Shot 2019-04-10 at 12 33 23 PM" src="https://user-images.githubusercontent.com/19270502/55900504-f7a75b00-5b8c-11e9-9685-b3b02aefe99d.png">
