### PR TITLE
Updated Carbon URL

### DIFF
--- a/src/content/practices/practices.md
+++ b/src/content/practices/practices.md
@@ -63,7 +63,7 @@ meets pragmatic.</span>
 <column lg="4" md="4" offset_lg="4">
 
 <tile
-    href="https://next.carbondesignsystem.com"
+    href="https://www.carbondesignsystem.com"
     dark="true"
     title="Product Design System">
 <img src="images/Image_2.png" alt=""/>


### PR DESCRIPTION
The product design system tile was still linking to next.carbondesignsystem.com
<img width="788" alt="Screen Shot 2019-04-18 at 9 56 20 AM" src="https://user-images.githubusercontent.com/19270502/56370156-59d11300-61c0-11e9-971c-3ce2998330d9.png">
